### PR TITLE
Revise Firebase security rules and add emulator tests

### DIFF
--- a/Downloads/skatehubba-app/firestore.rules
+++ b/Downloads/skatehubba-app/firestore.rules
@@ -1,97 +1,236 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    function isAuthed() { return request.auth != null; }
-    function isOwner(uid) { return isAuthed() && request.auth.uid == uid; }
-    function isGamePlayer(game) {
-      return isAuthed() &&
-        (game.data.players.A.uid == request.auth.uid ||
-         game.data.players.B.uid == request.auth.uid);
+    function isSignedIn() {
+      return request.auth != null;
     }
 
-    match /users/{uid} {
-      allow read: if isAuthed();
-      allow create: if isOwner(uid);
-      allow update: if isOwner(uid)
-        && request.resource.data.diff(resource.data).changedKeys().hasOnly([
-          'handle','bio','avatarUrl','stats','updatedAt'
-        ]);
-      allow delete: if false;
+    function otherSlot(slot) {
+      return slot == 'A' ? 'B' : 'A';
     }
 
-    match /leads/{id} {
-      allow create: if request.resource.data.keys().hasOnly(['email','source','createdAt']);
-      allow read, update, delete: if false;
+    function lettersValid(letters) {
+      return letters in ['','S','SK','SK8'];
     }
 
-    match /challenges/{cid} {
-      allow read: if true;
+    function validatePlayer(player) {
+      return player is map
+        && player.keys().hasOnly(['uid','name','letters'])
+        && player.uid is string
+        && player.name is string
+        && lettersValid(player.letters);
+    }
 
-      allow create: if isAuthed()
-        && request.resource.data.challengerUid == request.auth.uid
-        && request.resource.data.keys().hasOnly([
-          'challengerUid','opponentUid','trick','status',
-          'createdAt','updatedAt','expiresAt',
-          'challengerClipId','opponentClipId','winnerUid'
-        ])
-        && request.resource.data.status in ['pending','live']
-        && request.resource.data.createdAt is timestamp
-        && request.resource.data.updatedAt is timestamp
-        && request.resource.data.expiresAt is timestamp
-        && request.resource.data.winnerUid == null;
+    function validatePlayers(players) {
+      return players is map
+        && players.keys().hasOnly(['A','B'])
+        && validatePlayer(players.A)
+        && validatePlayer(players.B);
+    }
 
-      allow update: if isAuthed()
-        && request.resource.data.keys().hasOnly([
-          'status','updatedAt','challengerClipId','opponentClipId','winnerUid','opponentUid'
-        ])
-        && request.resource.data.updatedAt > resource.data.updatedAt
+    function validateCurrent(current) {
+      return current is map
+        && current.keys().hasOnly(['by','setVideoPath','responseVideoPath'])
+        && current.by in ['A','B']
+        && (!('setVideoPath' in current) || current.setVideoPath == null || current.setVideoPath is string)
+        && (!('responseVideoPath' in current) || current.responseVideoPath == null || current.responseVideoPath is string);
+    }
+
+    function validateHistoryItem(item) {
+      return item is map
+        && item.keys().hasOnly(['by','setPath','respPath','result','ts'])
+        && item.by in ['A','B']
+        && (!('setPath' in item) || item.setPath is string)
+        && (!('respPath' in item) || item.respPath is string)
+        && item.result in ['declined_set','approved_set','landed','failed']
+        && item.ts is timestamp;
+    }
+
+    function validateHistory(history) {
+      return history is list
+        && history.all(h, validateHistoryItem(h));
+    }
+
+    function validateTurn(turn) {
+      return turn in ['A','B'];
+    }
+
+    function validatePhase(phase) {
+      return phase in ['SET_RECORD','SET_JUDGE','RESP_RECORD','RESP_JUDGE'];
+    }
+
+    function validateWinner(winner) {
+      return winner == null || winner in ['A','B'];
+    }
+
+    function gameDoc(gameId) {
+      return get(/databases/$(database)/documents/games/$(gameId));
+    }
+
+    function validClipPath(gameId, slot, path) {
+      return path is string
+        && path.matches('^games/' + gameId + '/current/' + slot + '/[A-Za-z0-9_./-]{1,255}$');
+    }
+
+    function getSetPath(current) {
+      return ('setVideoPath' in current) ? current.setVideoPath : null;
+    }
+
+    function getRespPath(current) {
+      return ('responseVideoPath' in current) ? current.responseVideoPath : null;
+    }
+
+    function isParticipantData(data) {
+      return isSignedIn()
+        && data is map
+        && ('players' in data)
+        && data.players is map
+        && ((data.players.A.uid == request.auth.uid) || (data.players.B.uid == request.auth.uid));
+    }
+
+    function validateGame(data) {
+      return data is map
+        && data.keys().hasOnly(['code','turn','phase','winner','players','current','history','createdAt','updatedAt'])
+        && data.code is string
+        && validateTurn(data.turn)
+        && validatePhase(data.phase)
+        && validateWinner(data.winner)
+        && validatePlayers(data.players)
+        && validateCurrent(data.current)
+        && validateHistory(data.history)
+        && (!('createdAt' in data) || data.createdAt is timestamp)
+        && (!('updatedAt' in data) || data.updatedAt is timestamp);
+    }
+
+    function canSubmitSetClip(gameId, oldGame, newGame) {
+      let oldSet = getSetPath(oldGame.current);
+      let newSet = getSetPath(newGame.current);
+      return oldGame.phase == 'SET_RECORD'
+        && oldSet == null
+        && newSet is string
+        && validClipPath(gameId, oldGame.turn, newSet)
+        && request.auth.uid == oldGame.players[oldGame.turn].uid;
+    }
+
+    function canSubmitRespClip(gameId, oldGame, newGame) {
+      let oldResp = getRespPath(oldGame.current);
+      let newResp = getRespPath(newGame.current);
+      let responderSlot = otherSlot(oldGame.turn);
+      return oldGame.phase == 'RESP_RECORD'
+        && getSetPath(oldGame.current) is string
+        && oldResp == null
+        && newResp is string
+        && validClipPath(gameId, responderSlot, newResp)
+        && request.auth.uid == oldGame.players[responderSlot].uid;
+    }
+
+    function validateCurrentMutation(gameId, oldGame, newGame) {
+      let oldSet = getSetPath(oldGame.current);
+      let newSet = getSetPath(newGame.current);
+      let oldResp = getRespPath(oldGame.current);
+      let newResp = getRespPath(newGame.current);
+      let setChanged = oldSet != newSet;
+      let respChanged = oldResp != newResp;
+
+      return (!setChanged || (setChanged && !respChanged && canSubmitSetClip(gameId, oldGame, newGame)))
+        && (!respChanged || (respChanged && !setChanged && canSubmitRespClip(gameId, oldGame, newGame)));
+    }
+
+    function validateGameMutation(gameId) {
+      let oldGame = resource.data;
+      let newGame = request.resource.data;
+
+      return newGame.code == oldGame.code
+        && newGame.players.A.uid == oldGame.players.A.uid
+        && newGame.players.B.uid == oldGame.players.B.uid
+        && newGame.players.A.name == oldGame.players.A.name
+        && newGame.players.B.name == oldGame.players.B.name
+        && newGame.players.A.letters == oldGame.players.A.letters
+        && newGame.players.B.letters == oldGame.players.B.letters
+        && newGame.turn == oldGame.turn
+        && newGame.phase == oldGame.phase
+        && newGame.winner == oldGame.winner
+        && newGame.history == oldGame.history
+        && newGame.current.by == oldGame.current.by
+        && validateCurrentMutation(gameId, oldGame, newGame);
+    }
+
+    function intentKeys(type) {
+      return type == 'submit_set_clip' ? ['type','createdAt','phase','by','storagePath']
+        : type == 'submit_resp_clip' ? ['type','createdAt','phase','by','storagePath']
+        : type == 'judge_set' ? ['type','createdAt','phase','by','approve']
+        : type == 'judge_resp' ? ['type','createdAt','phase','by','landed']
+        : type == 'self_fail_set' ? ['type','createdAt','phase','by']
+        : type == 'self_fail_resp' ? ['type','createdAt','phase','by']
+        : [];
+    }
+
+    function isValidIntent(gameId, game, intentId, data) {
+      let allowedTypes = ['submit_set_clip','submit_resp_clip','judge_set','judge_resp','self_fail_set','self_fail_resp'];
+      return data is map
+        && data.type in allowedTypes
+        && data.keys().hasOnly(intentKeys(data.type))
+        && data.createdAt is timestamp
+        && data.phase == game.data.phase
+        && data.by in ['A','B']
+        && request.auth.uid == game.data.players[data.by].uid
+        && intentId == request.auth.uid + '_' + data.phase + '_' + data.type
         && (
-          (request.resource.data.challengerClipId == resource.data.challengerClipId
-            || request.auth.uid == resource.data.challengerUid)
-          &&
-          (request.resource.data.opponentClipId == resource.data.opponentClipId
-            || request.auth.uid == resource.data.opponentUid)
-        )
-        && (
-          (resource.data.winnerUid == null && request.resource.data.winnerUid in
-            [resource.data.challengerUid, resource.data.opponentUid])
-          || (request.resource.data.winnerUid == resource.data.winnerUid)
-        )
-        && (
-          (request.resource.data.opponentUid == resource.data.opponentUid) ||
-          (resource.data.opponentUid == null && request.resource.data.opponentUid == request.auth.uid)
+          (data.type == 'submit_set_clip'
+            && game.data.phase == 'SET_RECORD'
+            && data.by == game.data.turn
+            && getSetPath(game.data.current) == null
+            && data.storagePath is string
+            && validClipPath(gameId, data.by, data.storagePath))
+          || (data.type == 'submit_resp_clip'
+            && game.data.phase == 'RESP_RECORD'
+            && data.by == otherSlot(game.data.turn)
+            && getSetPath(game.data.current) is string
+            && getRespPath(game.data.current) == null
+            && data.storagePath is string
+            && validClipPath(gameId, data.by, data.storagePath))
+          || (data.type == 'judge_set'
+            && game.data.phase == 'SET_JUDGE'
+            && data.by == otherSlot(game.data.turn)
+            && data.approve is bool)
+          || (data.type == 'judge_resp'
+            && game.data.phase == 'RESP_JUDGE'
+            && data.by == game.data.turn
+            && data.landed is bool)
+          || (data.type == 'self_fail_set'
+            && game.data.phase == 'SET_RECORD'
+            && data.by == game.data.turn)
+          || (data.type == 'self_fail_resp'
+            && game.data.phase == 'RESP_RECORD'
+            && data.by == otherSlot(game.data.turn))
         );
-
-      allow delete: if false;
-    }
-
-    match /clips/{clipId} {
-      allow read: if true;
-      allow create: if isOwner(request.resource.data.ownerUid)
-        && request.resource.data.keys().hasOnly([
-          'ownerUid','challengeId','storagePath','durationMs','thumbUrl','createdAt'
-        ])
-        && request.resource.data.createdAt is timestamp;
-      allow update, delete: if false;
-    }
-
-    match /logs/{id} {
-      allow create: if isAuthed();
-      allow read, update, delete: if false;
     }
 
     match /games/{gameId} {
-      allow create: if isAuthed();
-      allow read: if isGamePlayer(resource);
-      allow update: if isGamePlayer(resource)
-        && request.resource.data.diff(resource.data).changedKeys()
-           .hasOnly(['turn','letters','winner','players','status']);
+      allow read: if resource != null && isParticipantData(resource.data);
+
+      allow create: if isSignedIn()
+        && validateGame(request.resource.data)
+        && isParticipantData(request.resource.data);
+
+      allow update: if isSignedIn()
+        && resource != null
+        && validateGame(request.resource.data)
+        && isParticipantData(resource.data)
+        && isParticipantData(request.resource.data)
+        && validateGameMutation(gameId);
+
       allow delete: if false;
-      match /tricks/{trickId} {
-        allow create, read: if isGamePlayer(
-          get(/databases/$(database)/documents/games/$(gameId))
-        );
+
+      match /intents/{intentId} {
+        allow read: if gameDoc(gameId).exists()
+          && isParticipantData(gameDoc(gameId).data);
+
+        allow create: if isSignedIn()
+          && gameDoc(gameId).exists()
+          && isParticipantData(gameDoc(gameId).data)
+          && isValidIntent(gameId, gameDoc(gameId), intentId, request.resource.data);
+
         allow update, delete: if false;
       }
     }

--- a/Downloads/skatehubba-app/package.json
+++ b/Downloads/skatehubba-app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:rules": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "firebase": "^11.10.0",
@@ -17,11 +18,13 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/Downloads/skatehubba-app/storage.rules
+++ b/Downloads/skatehubba-app/storage.rules
@@ -1,12 +1,71 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /games/{gameId}/tricks/{fileName} {
-      allow read, write: if request.auth != null;
+    function isSignedIn() {
+      return request.auth != null;
     }
-    match /clips/{fileName} {
+
+    function firestoreGame(gameId) {
+      return get(/databases/(default)/documents/games/$(gameId));
+    }
+
+    function otherSlot(slot) {
+      return slot == 'A' ? 'B' : 'A';
+    }
+
+    function isParticipant(game) {
+      return isSignedIn()
+        && game.exists()
+        && (game.data.players.A.uid == request.auth.uid || game.data.players.B.uid == request.auth.uid);
+    }
+
+    function allowedContentType() {
+      return request.resource != null
+        && request.resource.contentType in ['video/mp4','video/quicktime','video/webm'];
+    }
+
+    function withinSizeLimit() {
+      return request.resource != null && request.resource.size <= 125829120; // 120 MB
+    }
+
+    function currentPathValid(gameId, slot) {
+      return request.resource != null
+        && request.resource.name.matches('games/' + gameId + '/current/' + slot + '/[A-Za-z0-9_./-]{1,255}');
+    }
+
+    function canUploadCurrent(gameId, slot) {
+      let game = firestoreGame(gameId);
+      return request.resource != null
+        && isParticipant(game)
+        && slot in ['A','B']
+        && currentPathValid(gameId, slot)
+        && allowedContentType()
+        && withinSizeLimit()
+        && request.auth.uid == game.data.players[slot].uid
+        && ((game.data.phase == 'SET_RECORD'
+            && slot == game.data.turn
+            && (!('setVideoPath' in game.data.current) || game.data.current.setVideoPath == null))
+          || (game.data.phase == 'RESP_RECORD'
+            && slot == otherSlot(game.data.turn)
+            && ('setVideoPath' in game.data.current)
+            && game.data.current.setVideoPath is string
+            && (!('responseVideoPath' in game.data.current) || game.data.current.responseVideoPath == null)));
+    }
+
+    match /games/{gameId}/current/{slot}/{fileName} {
+      allow read: if firestoreGame(gameId).exists() && isParticipant(firestoreGame(gameId));
+      allow write: if canUploadCurrent(gameId, slot);
+      allow delete: if false;
+    }
+
+    match /games/{gameId}/history/{fileName} {
       allow read: if true;
-      allow write: if request.auth != null;
+      allow write: if false;
+      allow delete: if false;
+    }
+
+    match /{allPaths=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/Downloads/skatehubba-app/tests/rules/firestore.test.ts
+++ b/Downloads/skatehubba-app/tests/rules/firestore.test.ts
@@ -1,0 +1,270 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { Timestamp, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+  RulesTestContext,
+} from '@firebase/rules-unit-testing';
+
+describe('Firestore security rules', () => {
+  const projectId = 'skatehubba-firestore-rules';
+  const gameId = 'game123';
+  const firestoreRulesPath = path.resolve(__dirname, '../../firestore.rules');
+
+  let testEnv: RulesTestEnvironment;
+
+  const baseGame = {
+    code: 'ABCD12',
+    turn: 'A',
+    phase: 'SET_RECORD',
+    winner: null,
+    players: {
+      A: { uid: 'alice', name: 'Alice', letters: '' },
+      B: { uid: 'bob', name: 'Bob', letters: '' },
+    },
+    current: {
+      by: 'A',
+      setVideoPath: null,
+      responseVideoPath: null,
+    },
+    history: [] as Array<unknown>,
+    createdAt: Timestamp.fromMillis(0),
+    updatedAt: Timestamp.fromMillis(0),
+  };
+
+  const buildGame = (overrides: Partial<typeof baseGame> & {
+    players?: Partial<typeof baseGame.players>;
+    current?: Partial<typeof baseGame.current>;
+    history?: Array<unknown>;
+  } = {}) => {
+    return {
+      ...baseGame,
+      ...overrides,
+      players: {
+        A: { ...baseGame.players.A, ...(overrides.players?.A ?? {}) },
+        B: { ...baseGame.players.B, ...(overrides.players?.B ?? {}) },
+      },
+      current: {
+        ...baseGame.current,
+        ...(overrides.current ?? {}),
+      },
+      history: overrides.history ?? baseGame.history,
+    };
+  };
+
+  const seedGame = async (data?: Parameters<typeof buildGame>[0]) => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, 'games', gameId), buildGame(data));
+    });
+  };
+
+  const contextFor = (uid: string): RulesTestContext =>
+    testEnv.authenticatedContext(uid, { uid });
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId,
+      firestore: {
+        rules: readFileSync(firestoreRulesPath, 'utf8'),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedGame();
+  });
+
+  it('allows participants to read their game', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    await assertSucceeds(getDoc(doc(aliceDb, 'games', gameId)));
+  });
+
+  it('blocks non-participants from reading a game', async () => {
+    const charlieDb = testEnv.unauthenticatedContext().firestore();
+    await assertFails(getDoc(doc(charlieDb, 'games', gameId)));
+  });
+
+  it('prevents participants from changing phase or letters', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    await assertFails(
+      updateDoc(doc(aliceDb, 'games', gameId), {
+        phase: 'RESP_RECORD',
+      }),
+    );
+    await assertFails(
+      updateDoc(doc(aliceDb, 'games', gameId), {
+        'players.A.letters': 'SK',
+      }),
+    );
+  });
+
+  it('allows the active shooter to submit a set clip exactly once', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    await assertSucceeds(
+      updateDoc(doc(aliceDb, 'games', gameId), {
+        'current.setVideoPath': `games/${gameId}/current/A/clip.mp4`,
+      }),
+    );
+    await assertFails(
+      updateDoc(doc(aliceDb, 'games', gameId), {
+        'current.setVideoPath': `games/${gameId}/current/A/clip-2.mp4`,
+      }),
+    );
+  });
+
+  it('blocks the opponent from submitting the setter clip', async () => {
+    const bobDb = contextFor('bob').firestore();
+    await assertFails(
+      updateDoc(doc(bobDb, 'games', gameId), {
+        'current.setVideoPath': `games/${gameId}/current/B/clip.mp4`,
+      }),
+    );
+  });
+
+  it('allows the responder to submit a response clip once the game enters RESP_RECORD', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await updateDoc(doc(adminDb, 'games', gameId), {
+        phase: 'RESP_RECORD',
+        'current.setVideoPath': `games/${gameId}/current/A/clip.mp4`,
+      });
+    });
+
+    const bobDb = contextFor('bob').firestore();
+    await assertSucceeds(
+      updateDoc(doc(bobDb, 'games', gameId), {
+        'current.responseVideoPath': `games/${gameId}/current/B/resp.mp4`,
+      }),
+    );
+    await assertFails(
+      updateDoc(doc(bobDb, 'games', gameId), {
+        'current.responseVideoPath': `games/${gameId}/current/B/resp-second.mp4`,
+      }),
+    );
+  });
+
+  it('prevents response submissions before the phase is RESP_RECORD', async () => {
+    const bobDb = contextFor('bob').firestore();
+    await assertFails(
+      updateDoc(doc(bobDb, 'games', gameId), {
+        'current.responseVideoPath': `games/${gameId}/current/B/resp.mp4`,
+      }),
+    );
+  });
+
+  it('allows the setter to enqueue a set clip intent', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    await assertSucceeds(
+      setDoc(doc(aliceDb, 'games', gameId, 'intents', 'alice_SET_RECORD_submit_set_clip'), {
+        type: 'submit_set_clip',
+        createdAt: Timestamp.fromMillis(1),
+        phase: 'SET_RECORD',
+        by: 'A',
+        storagePath: `games/${gameId}/current/A/clip.mp4`,
+      }),
+    );
+  });
+
+  it('prevents duplicate set clip intents in the same phase', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    const intentRef = doc(aliceDb, 'games', gameId, 'intents', 'alice_SET_RECORD_submit_set_clip');
+    await assertSucceeds(
+      setDoc(intentRef, {
+        type: 'submit_set_clip',
+        createdAt: Timestamp.fromMillis(1),
+        phase: 'SET_RECORD',
+        by: 'A',
+        storagePath: `games/${gameId}/current/A/clip.mp4`,
+      }),
+    );
+    await assertFails(
+      setDoc(intentRef, {
+        type: 'submit_set_clip',
+        createdAt: Timestamp.fromMillis(2),
+        phase: 'SET_RECORD',
+        by: 'A',
+        storagePath: `games/${gameId}/current/A/clip-2.mp4`,
+      }),
+    );
+  });
+
+  it('allows the judge to record a decision only in the correct phase', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await updateDoc(doc(adminDb, 'games', gameId), {
+        phase: 'SET_JUDGE',
+        'current.setVideoPath': `games/${gameId}/current/A/clip.mp4`,
+      });
+    });
+
+    const bobDb = contextFor('bob').firestore();
+    await assertSucceeds(
+      setDoc(doc(bobDb, 'games', gameId, 'intents', 'bob_SET_JUDGE_judge_set'), {
+        type: 'judge_set',
+        createdAt: Timestamp.fromMillis(10),
+        phase: 'SET_JUDGE',
+        by: 'B',
+        approve: true,
+      }),
+    );
+
+    const aliceDb = contextFor('alice').firestore();
+    await assertFails(
+      setDoc(doc(aliceDb, 'games', gameId, 'intents', 'alice_SET_JUDGE_judge_set'), {
+        type: 'judge_set',
+        createdAt: Timestamp.fromMillis(11),
+        phase: 'SET_JUDGE',
+        by: 'A',
+        approve: true,
+      }),
+    );
+  });
+
+  it('restricts self-fail intents to the appropriate player and phase', async () => {
+    const aliceDb = contextFor('alice').firestore();
+    await assertSucceeds(
+      setDoc(doc(aliceDb, 'games', gameId, 'intents', 'alice_SET_RECORD_self_fail_set'), {
+        type: 'self_fail_set',
+        createdAt: Timestamp.fromMillis(20),
+        phase: 'SET_RECORD',
+        by: 'A',
+      }),
+    );
+
+    const bobDb = contextFor('bob').firestore();
+    await assertFails(
+      setDoc(doc(bobDb, 'games', gameId, 'intents', 'bob_SET_RECORD_self_fail_resp'), {
+        type: 'self_fail_resp',
+        createdAt: Timestamp.fromMillis(21),
+        phase: 'SET_RECORD',
+        by: 'B',
+      }),
+    );
+
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await updateDoc(doc(adminDb, 'games', gameId), {
+        phase: 'RESP_RECORD',
+        'current.setVideoPath': `games/${gameId}/current/A/clip.mp4`,
+      });
+    });
+
+    await assertSucceeds(
+      setDoc(doc(bobDb, 'games', gameId, 'intents', 'bob_RESP_RECORD_self_fail_resp'), {
+        type: 'self_fail_resp',
+        createdAt: Timestamp.fromMillis(22),
+        phase: 'RESP_RECORD',
+        by: 'B',
+      }),
+    );
+  });
+});

--- a/Downloads/skatehubba-app/tests/rules/storage.test.ts
+++ b/Downloads/skatehubba-app/tests/rules/storage.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestContext,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  getStorage,
+  ref,
+  uploadBytes,
+  getBytes,
+} from 'firebase/storage';
+import { doc, setDoc, updateDoc, Timestamp } from 'firebase/firestore';
+
+const SIZE_LIMIT = 125_829_120; // 120 MB
+
+describe('Storage security rules', () => {
+  const projectId = 'skatehubba-storage-rules';
+  const gameId = 'game123';
+  const firestoreRulesPath = path.resolve(__dirname, '../../firestore.rules');
+  const storageRulesPath = path.resolve(__dirname, '../../storage.rules');
+
+  let testEnv: RulesTestEnvironment;
+
+  const baseGame = {
+    code: 'ABCD12',
+    turn: 'A',
+    phase: 'SET_RECORD',
+    winner: null,
+    players: {
+      A: { uid: 'alice', name: 'Alice', letters: '' },
+      B: { uid: 'bob', name: 'Bob', letters: '' },
+    },
+    current: {
+      by: 'A',
+      setVideoPath: null,
+      responseVideoPath: null,
+    },
+    history: [] as Array<unknown>,
+    createdAt: Timestamp.fromMillis(0),
+    updatedAt: Timestamp.fromMillis(0),
+  };
+
+  const buildGame = (overrides: Partial<typeof baseGame> & {
+    players?: Partial<typeof baseGame.players>;
+    current?: Partial<typeof baseGame.current>;
+    history?: Array<unknown>;
+  } = {}) => ({
+    ...baseGame,
+    ...overrides,
+    players: {
+      A: { ...baseGame.players.A, ...(overrides.players?.A ?? {}) },
+      B: { ...baseGame.players.B, ...(overrides.players?.B ?? {}) },
+    },
+    current: {
+      ...baseGame.current,
+      ...(overrides.current ?? {}),
+    },
+    history: overrides.history ?? baseGame.history,
+  });
+
+  const seedGame = async (data?: Parameters<typeof buildGame>[0]) => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, 'games', gameId), buildGame(data));
+    });
+  };
+
+  const contextFor = (uid: string): RulesTestContext =>
+    testEnv.authenticatedContext(uid, { uid });
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId,
+      firestore: {
+        rules: readFileSync(firestoreRulesPath, 'utf8'),
+      },
+      storage: {
+        rules: readFileSync(storageRulesPath, 'utf8'),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.clearStorage();
+    await seedGame();
+  });
+
+  it('allows the active shooter to upload a set clip within limits', async () => {
+    const aliceStorage = getStorage(contextFor('alice').app);
+    const fileRef = ref(aliceStorage, `games/${gameId}/current/A/clip.mp4`);
+    await assertSucceeds(
+      uploadBytes(fileRef, new Uint8Array(1024), {
+        contentType: 'video/mp4',
+      }),
+    );
+  });
+
+  it('rejects uploads with disallowed MIME types', async () => {
+    const aliceStorage = getStorage(contextFor('alice').app);
+    const fileRef = ref(aliceStorage, `games/${gameId}/current/A/clip.mov`);
+    await assertFails(
+      uploadBytes(fileRef, new Uint8Array(1024), {
+        contentType: 'video/avi',
+      }),
+    );
+  });
+
+  it('enforces the 120 MB size ceiling', async () => {
+    const aliceStorage = getStorage(contextFor('alice').app);
+    const fileRef = ref(aliceStorage, `games/${gameId}/current/A/big.mp4`);
+    await assertFails(
+      uploadBytes(fileRef, new Uint8Array(SIZE_LIMIT + 1), {
+        contentType: 'video/mp4',
+      }),
+    );
+  });
+
+  it('blocks non-shooters from writing to the current clip path', async () => {
+    const bobStorage = getStorage(contextFor('bob').app);
+    const fileRef = ref(bobStorage, `games/${gameId}/current/B/clip.mp4`);
+    await assertFails(
+      uploadBytes(fileRef, new Uint8Array(1024), {
+        contentType: 'video/mp4',
+      }),
+    );
+  });
+
+  it('allows the responder to upload only during RESP_RECORD', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await updateDoc(doc(adminDb, 'games', gameId), {
+        phase: 'RESP_RECORD',
+        'current.setVideoPath': `games/${gameId}/current/A/clip.mp4`,
+      });
+    });
+
+    const bobStorage = getStorage(contextFor('bob').app);
+    const respRef = ref(bobStorage, `games/${gameId}/current/B/resp.mp4`);
+    await assertSucceeds(
+      uploadBytes(respRef, new Uint8Array(2048), {
+        contentType: 'video/mp4',
+      }),
+    );
+
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await updateDoc(doc(adminDb, 'games', gameId), {
+        'current.responseVideoPath': `games/${gameId}/current/B/resp.mp4`,
+      });
+    });
+
+    await assertFails(
+      uploadBytes(respRef, new Uint8Array(2048), {
+        contentType: 'video/mp4',
+      }),
+    );
+  });
+
+  it('makes history clips world-readable', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const storage = getStorage(context.app);
+      const historyRef = ref(storage, `games/${gameId}/history/round1.mp4`);
+      await uploadBytes(historyRef, new Uint8Array(10), {
+        contentType: 'video/mp4',
+      });
+    });
+
+    const anonStorage = getStorage(testEnv.unauthenticatedContext().app);
+    const historyRef = ref(anonStorage, `games/${gameId}/history/round1.mp4`);
+    await assertSucceeds(getBytes(historyRef));
+  });
+});

--- a/Downloads/skatehubba-app/vitest.config.ts
+++ b/Downloads/skatehubba-app/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    hookTimeout: 60000,
+    testTimeout: 60000,
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- overhaul Firestore rules to gate access to game documents, restrict client mutations to clip intents, and validate the S.K.8 data model
- tighten Storage rules to constrain uploads to the active shooter, enforce size and MIME limits, and expose history clips for public playback
- introduce vitest-based Firebase emulator unit tests covering positive and negative scenarios for both Firestore and Storage rules

## Testing
- `npm run test:rules` *(fails: vitest binary unavailable because new dev dependencies cannot be installed in the offline execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d015cf25648333a70b7b2bfe21ad9b