### PR TITLE
Tighten storage rules for challenge clips

### DIFF
--- a/Downloads/skatehubba-app/package.json
+++ b/Downloads/skatehubba-app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:storage": "node tests/storage-rules.test.js"
   },
   "dependencies": {
     "firebase": "^11.10.0",
@@ -22,6 +23,7 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@firebase/rules-unit-testing": "^3.0.0"
   }
 }

--- a/Downloads/skatehubba-app/storage.rules
+++ b/Downloads/skatehubba-app/storage.rules
@@ -1,12 +1,69 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /games/{gameId}/tricks/{fileName} {
-      allow read, write: if request.auth != null;
+    function isAuthed() {
+      return request.auth != null;
     }
+
+    function getGame(gameId) {
+      return firestore.get(/databases/(default)/documents/games/$(gameId));
+    }
+
+    function otherPlayer(key) {
+      return key == 'A' ? 'B' : 'A';
+    }
+
+    function isRecordingPhase(game) {
+      return game.data.phase in ['SET_RECORD', 'RESP_RECORD'];
+    }
+
+    function shooterUid(game) {
+      let by = game.data.current.by;
+      let setter = game.data.players[by];
+      let responder = game.data.players[otherPlayer(by)];
+      return game.data.phase == 'RESP_RECORD' ? responder.uid : setter.uid;
+    }
+
+    function hasActiveShooter(game, uploaderUid) {
+      return game != null
+        && game.data != null
+        && game.data.players != null
+        && game.data.current != null
+        && game.data.current.by != null
+        && game.data.players[game.data.current.by] != null
+        && game.data.players[otherPlayer(game.data.current.by)] != null
+        && isRecordingPhase(game)
+        && shooterUid(game) == uploaderUid;
+    }
+
+    function isShooterForGame(gameId, uploaderUid) {
+      let game = getGame(gameId);
+      return hasActiveShooter(game, uploaderUid);
+    }
+
+    function isAllowedUpload() {
+      return request.resource.size <= 120 * 1024 * 1024
+        && request.resource.contentType != null
+        && request.resource.contentType.matches('^video/(mp4|quicktime|webm)$');
+    }
+
+    match /challenges/{gameId}/{uploaderUid}/{fileName} {
+      allow read: if true;
+
+      allow create: if isAuthed()
+        && request.auth.uid == uploaderUid
+        && resource == null
+        && isAllowedUpload()
+        && isShooterForGame(gameId, uploaderUid);
+
+      allow update, delete: if false;
+    }
+
     match /clips/{fileName} {
       allow read: if true;
-      allow write: if request.auth != null;
+      allow create: if isAuthed()
+        && resource == null;
+      allow update, delete: if false;
     }
   }
 }

--- a/Downloads/skatehubba-app/tests/storage-rules.test.js
+++ b/Downloads/skatehubba-app/tests/storage-rules.test.js
@@ -1,0 +1,92 @@
+const { initializeTestEnvironment, assertSucceeds, assertFails } = require('@firebase/rules-unit-testing');
+const { readFileSync } = require('fs');
+require('firebase/compat/app');
+require('firebase/compat/firestore');
+require('firebase/compat/storage');
+
+const PROJECT_ID = 'skatehubba-test';
+const STORAGE_RULES = readFileSync('storage.rules', 'utf8');
+const FIRESTORE_RULES = readFileSync('firestore.rules', 'utf8');
+
+async function seedGame(testEnv, gameId, data) {
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    const db = context.firestore();
+    await db.doc(`games/${gameId}`).set(data);
+  });
+}
+
+async function setupEnvironment() {
+  return initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: { rules: FIRESTORE_RULES },
+    storage: { rules: STORAGE_RULES },
+  });
+}
+
+async function run() {
+  const testEnv = await setupEnvironment();
+  try {
+    const baseGame = {
+      phase: 'SET_RECORD',
+      current: { by: 'A' },
+      players: {
+        A: { uid: 'setterUid' },
+        B: { uid: 'responderUid' },
+      },
+    };
+
+    await seedGame(testEnv, 'game-set', baseGame);
+    const setterCtx = testEnv.authenticatedContext('setterUid');
+    const setRef = setterCtx.storage().ref('challenges/game-set/setterUid/set.mp4');
+    await assertSucceeds(setRef.put(Buffer.from('set'), { contentType: 'video/mp4' }));
+
+    await testEnv.clearStorage();
+    await testEnv.clearFirestore();
+
+    await seedGame(testEnv, 'game-resp', {
+      ...baseGame,
+      phase: 'RESP_RECORD',
+    });
+    const responderCtx = testEnv.authenticatedContext('responderUid');
+    const respRef = responderCtx.storage().ref('challenges/game-resp/responderUid/resp.webm');
+    await assertSucceeds(respRef.put(Buffer.from('resp'), { contentType: 'video/webm' }));
+
+    const wrongUserCtx = testEnv.authenticatedContext('intruder');
+    await assertFails(
+      wrongUserCtx
+        .storage()
+        .ref('challenges/game-resp/intruder/hack.mp4')
+        .put(Buffer.from('hack'), { contentType: 'video/mp4' })
+    );
+
+    await assertFails(
+      responderCtx
+        .storage()
+        .ref('challenges/game-resp/responderUid/notallowed.avi')
+        .put(Buffer.from('bad'), { contentType: 'video/avi' })
+    );
+
+    await testEnv.clearStorage();
+    await seedGame(testEnv, 'game-overwrite', baseGame);
+    const overwriteCtx = testEnv.authenticatedContext('setterUid');
+    const overwriteRef = overwriteCtx.storage().ref('challenges/game-overwrite/setterUid/set.mov');
+    await assertSucceeds(overwriteRef.put(Buffer.from('first'), { contentType: 'video/quicktime' }));
+    await assertFails(overwriteRef.put(Buffer.from('second'), { contentType: 'video/quicktime' }));
+
+    await testEnv.clearStorage();
+    await testEnv.clearFirestore();
+
+    await seedGame(testEnv, 'game-size', baseGame);
+    const bigCtx = testEnv.authenticatedContext('setterUid');
+    const bigRef = bigCtx.storage().ref('challenges/game-size/setterUid/big.mp4');
+    const tooBig = Buffer.alloc(121 * 1024 * 1024);
+    await assertFails(bigRef.put(tooBig, { contentType: 'video/mp4' }));
+  } finally {
+    await testEnv.cleanup();
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- enforce shooter-only uploads to challenges/* clips with video size and mime checks
- retain public read access while disallowing overwrites of finalized clips
- add storage rules emulator test harness to validate allowed and denied flows

## Testing
- `npm run test:storage` *(fails: missing @firebase/rules-unit-testing dependency in sandbox registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d02fa4042c833397d26e0adfdd9647